### PR TITLE
build: add vr build support

### DIFF
--- a/xmake-requires.lock
+++ b/xmake-requires.lock
@@ -9,7 +9,7 @@
                 commit = "d885463d7cea3253b436ded2f4f17fd8423c4eaa",
                 url = "https://github.com/xmake-io/xmake-repo.git"
             },
-            version = "3.30.3"
+            version = "3.30.0"
         },
         ["directxmath#9c36f0a9"] = {
             repo = {
@@ -42,6 +42,14 @@
                 url = "https://github.com/xmake-io/xmake-repo.git"
             },
             version = "v3.11.3"
+        },
+        ["rapidcsv#31fecfc4"] = {
+            repo = {
+                branch = "master",
+                commit = "06eef0d257af5da49b023c8dec39f9d2700f608f",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "8.83"
         },
         ["spdlog#9c36f0a9"] = {
             repo = {

--- a/xmake.lua
+++ b/xmake.lua
@@ -31,7 +31,7 @@ set_encodings("source:utf-8", "target:utf-8")
 -- set configs
 set_config("skyrim_se", true)
 set_config("skyrim_ae", true)
-set_config("skyrim_vr", false) -- no xmake support it seems
+set_config("skyrim_vr", true)
 
 -- set requires
 add_requires("spdlog", { configs = { header_only = false, wchar = true, std_format = true } })


### PR DESCRIPTION
Fixed clib-ng not building in vr with this PR https://github.com/alandtse/CommonLibVR/pull/70, so can now enable VR building